### PR TITLE
allow multiple services with same name and service naming

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -83,7 +83,7 @@ class Configuration implements ConfigurationInterface
               ->scalarNode('cf_domain')->cannotBeEmpty()->isRequired()->end()
               ->arrayNode('cf_services')
                 ->useAttributeAsKey('name')
-                ->prototype('scalar')
+                ->prototype('variable')
                 ->end()
               ->end()
               ->arrayNode('cf_environment_vars')

--- a/src/Services/CloudFoundry/DeploymentUtils.php
+++ b/src/Services/CloudFoundry/DeploymentUtils.php
@@ -59,8 +59,16 @@ final class DeploymentUtils
         }
 
         $steps = [];
-        foreach ($configuration['cf_services'] as $service => $type) {
-            $steps[] = new StepCreateService($configuration, $applicationName, $service, $type);
+        foreach ($configuration['cf_services'] as $service => $plan) {
+            $name = null;
+            $type = $service;
+            if (is_array($plan)) {
+                $name = $service;
+                $type = $plan['service'];
+                $plan = $plan['plan'];
+
+            }
+            $steps[] = new StepCreateService($configuration, $applicationName, $type, $plan, $name);
             $steps[] = new StepBindService($configuration, $applicationName, $slice, $service);
         }
 

--- a/src/Steps/CloudFoundry/StepCreateService.php
+++ b/src/Steps/CloudFoundry/StepCreateService.php
@@ -13,14 +13,26 @@ namespace Graviton\Deployment\Steps\CloudFoundry;
  */
 final class StepCreateService extends AbstractStep
 {
-    /** @var string  */
-    private $serviceName;
-
-    /** @var string  */
+    /**
+     * @var string
+     */
     private $applicationName;
 
-    /** @var string  */
+    /**
+     * @var string
+     */
     private $serviceType;
+
+    /*
+     * @var string
+     */
+    private $servicePlan;
+
+    /**
+     * @var string
+     */
+    private $serviceName;
+
 
     /**
      *
@@ -29,16 +41,20 @@ final class StepCreateService extends AbstractStep
      *
      * @param array  $configuration   Current application configuration.
      * @param string $applicationName Name of the CF-application to be checked
-     * @param string $serviceName     Name of the CF service to create
-     * @param string $serviceType     Name of the CF service type to create
+     * @param string $serviceType     Type of the CF service to create
+     * @param string $servicePlan     Plan of the CF service to create
+     * @param string $serviceName     Name of the CF service to create, defaults to $serviceType
      */
-    public function __construct(array $configuration, $applicationName, $serviceName, $serviceType)
+    public function __construct(array $configuration, $applicationName, $serviceType, $servicePlan, $serviceName = null)
     {
         parent::__construct($configuration);
 
         $this->applicationName = $applicationName;
-        $this->serviceName = $serviceName;
         $this->serviceType = $serviceType;
+        $this->servicePlan = $servicePlan;
+        if (is_null($serviceName)) {
+            $this->serviceName = $serviceType;
+        }
     }
 
     /**
@@ -51,8 +67,8 @@ final class StepCreateService extends AbstractStep
         return array(
             $this->configuration['cf_bin'],
             'cs',
-            $this->serviceName,
             $this->serviceType,
+            $this->servicePlan,
             $this->applicationName . '-' . $this->serviceName
         );
     }

--- a/src/Steps/CloudFoundry/StepCreateService.php
+++ b/src/Steps/CloudFoundry/StepCreateService.php
@@ -52,6 +52,7 @@ final class StepCreateService extends AbstractStep
         $this->applicationName = $applicationName;
         $this->serviceType = $serviceType;
         $this->servicePlan = $servicePlan;
+        $this->serviceName = $serviceName;
         if (is_null($serviceName)) {
             $this->serviceName = $serviceType;
         }

--- a/src/Tests/Command/CloudFoundry/DeployCommandTest.php
+++ b/src/Tests/Command/CloudFoundry/DeployCommandTest.php
@@ -65,6 +65,8 @@ Pushing graviton-unstable-green to Cloud Foundry.
 Creating services... done
 cs mongodb free graviton-unstable-mongodb
 bind-service graviton-unstable-green graviton-unstable-mongodb
+cs mongodb free graviton-unstable-test
+bind-service graviton-unstable-green graviton-unstable-test
 
 Defining environment variables... done
 set-env graviton-unstable-green ERRBIT_API_KEY some_secret_key
@@ -94,6 +96,8 @@ Pushing graviton-master-green to Cloud Foundry.
 Creating services... done
 cs mongodb free graviton-master-mongodb
 bind-service graviton-master-green graviton-master-mongodb
+cs mongodb free graviton-master-test
+bind-service graviton-master-green graviton-master-test
 
 Defining environment variables... done
 set-env graviton-master-green ERRBIT_API_KEY some_secret_key

--- a/src/Tests/Resources/config/deploy.yml
+++ b/src/Tests/Resources/config/deploy.yml
@@ -10,5 +10,8 @@ deploy-scripts:
   cf_domain: DOMAIN
   cf_services:
     mongodb: free
+    test:
+        service: mongodb
+        plan: free
   cf_environment_vars:
     ERRBIT_API_KEY: some_secret_key


### PR DESCRIPTION
After these changes the you can either specify services as before or using the new extended syntax:

```yml
cf_services:
  mariadb: free
  another-mariadb:
    service: mariadb
    plan: free
```

This would create both ``<app-name>-<stability>-mariadb`` and ``<app-name>-<stability>-another-mariadb`` as bound instances of the ``mariadb`` service using the ``free`` plan.